### PR TITLE
Add azure report URL to Slack messages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,11 @@ const argv = yargs(hideBin(process.argv))
           type: 'string',
           description: 'Title of notification',
           default: "Test Results",
+        })
+        .option('azureReportUrl', {
+          alias: 'a',
+          type: 'string',
+          description: 'URL to the Azure report',
         });
     },
     async (argv) => {
@@ -37,7 +42,7 @@ const argv = yargs(hideBin(process.argv))
           console.log('No failed tests. Message not sent.');
           return;
         }
-        const message = formatResultsMessage(ctrfData, {title: argv.title});
+        const message = formatResultsMessage(ctrfData, {title: argv.title, azureReportUrl: argv.azureReportUrl});
         await sendSlackMessage(message);
         console.log('Results message sent to Slack.');
       } catch (error: any) {
@@ -65,13 +70,18 @@ const argv = yargs(hideBin(process.argv))
         type: 'boolean',
         description: 'Consolidate all failure summaries into a single message',
         default: false,
+      })
+      .option('azureReportUrl', {
+        alias: 'a',
+        type: 'string',
+        description: 'URL to the Azure report',
       });
     },
     async (argv) => {
       try {
         const ctrfData = stripAnsiFromErrors(parseCtrfFile(argv.path as string))
         if (argv.consolidated) {
-            const message = formatConsolidatedFailedTestSummary(ctrfData.results.tests, ctrfData.results.environment, {title: argv.title})
+            const message = formatConsolidatedFailedTestSummary(ctrfData.results.tests, ctrfData.results.environment, {title: argv.title, azureReportUrl: argv.azureReportUrl})
             if (message) {
               await sendSlackMessage(message);
               console.log('Failed test summary sent to Slack.');
@@ -81,7 +91,7 @@ const argv = yargs(hideBin(process.argv))
         } else {
         for (const test of ctrfData.results.tests) {
           if (test.status === "failed") {
-            const message = formatFailedTestSummary(test, ctrfData.results.environment, {title: argv.title});
+            const message = formatFailedTestSummary(test, ctrfData.results.environment, {title: argv.title, azureReportUrl: argv.azureReportUrl});
             if (message) {
               await sendSlackMessage(message);
               console.log('Failed test summary sent to Slack.');
@@ -109,12 +119,17 @@ const argv = yargs(hideBin(process.argv))
         type: 'string',
         description: 'Title of notification',
         default: "Flaky Tests",
+      })
+      .option('azureReportUrl', {
+        alias: 'a',
+        type: 'string',
+        description: 'URL to the Azure report',
       });
     },
     async (argv) => {
       try {
         const ctrfData = parseCtrfFile(argv.path as string);
-        const message = formatFlakyTestsMessage(ctrfData, {title: argv.title});
+        const message = formatFlakyTestsMessage(ctrfData, {title: argv.title, azureReportUrl: argv.azureReportUrl});
         if (message) {
           await sendSlackMessage(message);
           console.log('Flaky tests message sent to Slack.');
@@ -146,13 +161,18 @@ const argv = yargs(hideBin(process.argv))
         type: 'boolean',
         description: 'Consolidate all failure summaries into a single message',
         default: false,
+      })
+      .option('azureReportUrl', {
+        alias: 'a',
+        type: 'string',
+        description: 'URL to the Azure report',
       });
     },
     async (argv) => {
       try {
         const ctrfData = parseCtrfFile(argv.path as string);
         if (argv.consolidated) {
-            const message = formatConsolidatedAiTestSummary(ctrfData.results.tests, ctrfData.results.environment, {title: argv.title})
+            const message = formatConsolidatedAiTestSummary(ctrfData.results.tests, ctrfData.results.environment, {title: argv.title, azureReportUrl: argv.azureReportUrl})
             if (message) {
               await sendSlackMessage(message);
               console.log('AI test summary sent to Slack.');
@@ -162,7 +182,7 @@ const argv = yargs(hideBin(process.argv))
         } else {
         for (const test of ctrfData.results.tests) {
           if (test.status === "failed") {
-            const message = formatAiTestSummary(test, ctrfData.results.environment, {title: argv.title});
+            const message = formatAiTestSummary(test, ctrfData.results.environment, {title: argv.title, azureReportUrl: argv.azureReportUrl});
             if (message) {
               await sendSlackMessage(message);
               console.log('AI test summary sent to Slack.');

--- a/src/message-formatter.ts
+++ b/src/message-formatter.ts
@@ -2,7 +2,8 @@ import { CtrfEnvironment, CtrfReport, CtrfTest } from '../types/ctrf';
 
 type Options =
   {
-    title: string
+    title: string,
+    azureReportUrl?: string
   }
 
 export const formatResultsMessage = (ctrf: CtrfReport, options?: Options): object => {
@@ -89,12 +90,22 @@ export const formatResultsMessage = (ctrf: CtrfReport, options?: Options): objec
     });
   }
 
+  if (options?.azureReportUrl) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${options.azureReportUrl}|Azure Report>`
+      }
+    });
+  }
+
   blocks.push({
     type: "context",
     elements: [
       {
         type: "mrkdwn",
-        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter>"
+        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>"
       }
     ]
   });
@@ -185,12 +196,22 @@ export const formatFlakyTestsMessage = (ctrf: CtrfReport, options?: Options): ob
     });
   }
 
+  if (options?.azureReportUrl) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${options.azureReportUrl}|Azure Report>`
+      }
+    });
+  }
+
   blocks.push({
     type: "context",
     elements: [
       {
         type: "mrkdwn",
-        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter>"
+        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>"
       }
     ]
   });
@@ -286,12 +307,22 @@ export const formatAiTestSummary = (test: CtrfTest, environment: CtrfEnvironment
     });
   }
 
+  if (options?.azureReportUrl) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${options.azureReportUrl}|Azure Report>`
+      }
+    });
+  }
+
   blocks.push({
     type: "context",
     elements: [
       {
         type: "mrkdwn",
-        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter>"
+        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>"
       }
     ]
   });
@@ -397,6 +428,16 @@ export const formatConsolidatedAiTestSummary = (
     });
   }
 
+  if (options?.azureReportUrl) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${options.azureReportUrl}|Azure Report>`
+      }
+    });
+  }
+
   if (failedTests.length > MAX_FAILED_TESTS) {
     blocks.push({
       type: "section",
@@ -412,7 +453,7 @@ export const formatConsolidatedAiTestSummary = (
     elements: [
       {
         type: "mrkdwn",
-        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter>"
+        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>"
       }
     ]
   });
@@ -522,6 +563,16 @@ export const formatConsolidatedFailedTestSummary = (
     });
   }
 
+  if (options?.azureReportUrl) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${options.azureReportUrl}|Azure Report>`
+      }
+    });
+  }
+
   if (failedTests.length > MAX_FAILED_TESTS) {
     blocks.push({
       type: "section",
@@ -537,7 +588,7 @@ export const formatConsolidatedFailedTestSummary = (
     elements: [
       {
         type: "mrkdwn",
-        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter>"
+        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>"
       }
     ]
   });
@@ -639,12 +690,22 @@ export const formatFailedTestSummary = (test: CtrfTest, environment: CtrfEnviron
     });
   }
 
+  if (options?.azureReportUrl) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${options.azureReportUrl}|Azure Report>`
+      }
+    });
+  }
+
   blocks.push({
     type: "context",
     elements: [
       {
         type: "mrkdwn",
-        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter>"
+        text: "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>"
       }
     ]
   });
@@ -658,9 +719,3 @@ export const formatFailedTestSummary = (test: CtrfTest, environment: CtrfEnviron
     ]
   };
 };
-
-
-
-
-
-


### PR DESCRIPTION
Add a new Slack block with a clickable Azure report URL to formatted messages.

* Modify `src/cli.ts` to handle the `--azureReportUrl` parameter for all commands.
* Update message formatting functions in `src/message-formatter.ts` to include logic for adding a clickable block with the `azureReportUrl` link if provided.
* Update the `sendSlackMessage` function in `src/slack-notify.ts` to consider the `--azureReportUrl` parameter.
* Update `yargs` command definitions in `src/cli.ts` to include an option for `--azureReportUrl`.
* Update Slack block text to "<https://github.com/ctrf-io/slack-ctrf|Slack CTRF Test Reporter V2>" in all relevant functions in `src/message-formatter.ts`.

